### PR TITLE
Always show links to runs in Activity

### DIFF
--- a/src/app/(dynamic-pages)/(authenticated-pages)/(application-pages)/org/[organizationId]/(specific-organization-pages)/activity/AllActivityTable.tsx
+++ b/src/app/(dynamic-pages)/(authenticated-pages)/(application-pages)/org/[organizationId]/(specific-organization-pages)/activity/AllActivityTable.tsx
@@ -49,28 +49,18 @@ export const AllActivityTable = ({ runs, allowedRunsForUser }: {
                                 transition={{ duration: 0.3 }}
                             >
                                 <TableCell>
-                                    {allowedRunsForUser.includes(run.id) ? (
-                                        <Link href={`/project/${run.project_slug}/runs/${run.id}`} className="hover:underline cursor-pointer">
-                                            <span>
-                                                {run.id.length > 8 ? `${run.id.substring(0, 8)}...` : run.id}
-                                            </span>
-                                        </Link>
-                                    ) : (
+                                    <Link href={`/project/${run.project_slug}/runs/${run.id}`} className="hover:underline cursor-pointer">
                                         <span>
                                             {run.id.length > 8 ? `${run.id.substring(0, 8)}...` : run.id}
                                         </span>
-                                    )}
+                                    </Link>
                                 </TableCell>
-                                {allowedRunsForUser.includes(run.id) ?
-                                    <TableCell>
-                                        <Link href={`https://github.com/${run.repo_full_name}/commit/${run.commit_id}`}
-                                            className="hover:underline cursor-pointer">
-                                            {run.commit_id.substring(0, 8)}
-                                        </Link>
-                                    </TableCell>
-                                    :
-                                    <TableCell>{run.commit_id.substring(0, 8)}</TableCell>
-                                }
+                                <TableCell>
+                                    <Link href={`https://github.com/${run.repo_full_name}/commit/${run.commit_id}`}
+                                        className="hover:underline cursor-pointer">
+                                        {run.commit_id.substring(0, 8)}
+                                    </Link>
+                                </TableCell>
                                 <TableCell>
                                     <span className={`px-2 py-1 rounded-full text-xs font-medium ${statusColors[ToSnakeCase(run.status)] || ''}`}>
                                         {run.status.toUpperCase()}


### PR DESCRIPTION
Links were only shown for user's projects. It's understandable but not intuitive.
Acceptable options:
- only show runs from user's projects (but that would make Activity useless)
- show links to all runs in the org

For now choosing #2 

Later we'll probably need to rethink Activity alongside Teams / RBAC (who can see what) with some kind of a UI to assign projects to teams, and roles (view only or modifications allowed, etc)

