### PR TITLE
Only show drifted projects on the Drift page

### DIFF
--- a/src/app/(dynamic-pages)/(authenticated-pages)/(application-pages)/org/[organizationId]/(specific-organization-pages)/drift/DriftedProjectsWithPagination.tsx
+++ b/src/app/(dynamic-pages)/(authenticated-pages)/(application-pages)/org/[organizationId]/(specific-organization-pages)/drift/DriftedProjectsWithPagination.tsx
@@ -15,7 +15,7 @@ export async function UserDriftedProjectsWithPagination({
         getLoggedInUserOrganizationRole(organizationId)
     ]);
     const [projects, totalPages] = await Promise.all([
-        getProjectsListForUser({ ...filters, organizationId, userRole, userId }),
+        getProjectsListForUser({ ...filters, organizationId, userRole, userId, driftedOnly: true }),
         getProjectsCountForUser({ ...filters, organizationId, userId }),
     ]);
 

--- a/src/app/(dynamic-pages)/(authenticated-pages)/(application-pages)/org/[organizationId]/(specific-organization-pages)/drift/page.tsx
+++ b/src/app/(dynamic-pages)/(authenticated-pages)/(application-pages)/org/[organizationId]/(specific-organization-pages)/drift/page.tsx
@@ -25,7 +25,7 @@ export default async function DriftsPage({
   return (
     <div className="flex flex-col space-y-4 max-w-5xl mt-8">
       <PageHeading
-        title="Drifted projects (alpha)"
+        title="Drifted projects"
       />
       <div className="md:w-1/3">
         <Search placeholder="Search projects" />


### PR DESCRIPTION
Currently the Drift page (top level) is showing all projects

Changing to only show ones with non-empty drift
